### PR TITLE
Added use statements for enums which are not namespaced

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -2,8 +2,9 @@
 #![allow(non_uppercase_statics)]
 
 use std::io;
-
 use peeker::Peeker;
+use self::MpegVersion::*;
+use self::MpegLayer::*;
 
 #[derive(Debug)]
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
This is to fix "error: unresolved name <enum variant>"
