### PR TITLE
Added parentheses due to change of precedence of '+' in type grammar

### DIFF
--- a/src/bitreader.rs
+++ b/src/bitreader.rs
@@ -1,7 +1,9 @@
 use std::io;
 
 pub struct BitReader<'a> {
-  pub cache: u8, pub cache_length: uint, reader: &'a mut io::Reader + 'a
+  pub cache: u8,
+  pub cache_length: u32,
+  reader: &'a mut (old_io::Reader + 'a)
 }
 
 impl<'a> BitReader<'a> {

--- a/src/bitreader.rs
+++ b/src/bitreader.rs
@@ -1,7 +1,9 @@
 use std::old_io;
 
 pub struct BitReader<'a> {
-  pub cache: u8, pub cache_length: u32, reader: &'a mut old_io::Reader + 'a
+  pub cache: u8,
+  pub cache_length: u32,
+  reader: &'a mut (old_io::Reader + 'a)
 }
 
 impl<'a> BitReader<'a> {


### PR DESCRIPTION
See RFC 438
